### PR TITLE
Update website to reflect AWS role

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ timezone: Europe/London
 
 title: Richard Baguley                       # the main title
 
-tagline: Richard Baguley is a Principal Technical Architect doing computer stuff at MoJ  # it will display as the sub-title
+tagline: Richard Baguley is a Senior Solutions Architect at AWS helping customers build cloud solutions  # it will display as the sub-title
 
 description: >-                        # used by seo meta and the atom feed
   Richard Baguley a London based Technical Architect

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -7,8 +7,8 @@ Hello 👋
 I am Richard Baguley, a Senior Solutions Architect working at Amazon Web Services (AWS).
 
 ## Latest work
-[Amazon Web Services](https://aws.amazon.com/) - `Senior Solutions Architect`
-> Working with customers to design and implement cloud solutions on AWS.
+[Amazon Web Services](https://aws.amazon.com/) - `Customer Solutions Architect` (UK Defense & Intelligence)
+> Working with UK defense and government customers to design and implement cloud solutions on AWS, specializing in data analytics, AI/ML, and secure cloud platforms.
 
 ## Previous roles
 [Ministry of Justice](https://www.gov.uk/government/organisations/ministry-of-justice) - `Principal Technical Architect` [Analytical Platform](https://user-guidance.analytical-platform.service.justice.gov.uk/)


### PR DESCRIPTION
## Changes

Updates website content to reflect current role at AWS:

**Tagline (_config.yml):**
- ❌ Old: "Principal Technical Architect doing computer stuff at MoJ"
- ✅ New: "Senior Solutions Architect at AWS helping customers build cloud solutions"

**About Page (_tabs/about.md):**
- ✅ Updated job title: **Customer Solutions Architect** (UK Defense & Intelligence)
- ✅ Added specialization: data analytics, AI/ML, secure cloud platforms
- ✅ MoJ history remains under "Previous roles" (accurate)

## Why
The sidebar and meta description still showed the old MoJ role, causing confusion on the live site.

## Testing
- [ ] Local Jekyll build
- [ ] Deploy preview
- [ ] Verify sidebar shows AWS role
- [ ] Check meta description updated